### PR TITLE
Fix global installation via remote URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can install this CLI globally using Deno's install command:
 
 ```bash
 # Install from the repository
-deno install --global --config=https://raw.githubusercontent.com/Sapphillon/Sapphillon_CLI/main/deno.json --allow-read --allow-write --allow-net --allow-run --allow-env -n sapphillon https://raw.githubusercontent.com/Sapphillon/Sapphillon_CLI/main/main.ts
+deno install --global --allow-read --allow-write --allow-net --allow-run --allow-env -n sapphillon https://raw.githubusercontent.com/Sapphillon/Sapphillon_CLI/main/main.ts
 
 # Or if you've cloned the repository locally
 deno install --global --allow-read --allow-write --allow-net --allow-run --allow-env -n sapphillon main.ts

--- a/src/utils/bundler.ts
+++ b/src/utils/bundler.ts
@@ -3,8 +3,8 @@
  * Produces IIFE format output (similar to webpack)
  */
 
-import * as esbuild from "esbuild";
-import { denoPlugins } from "@luca/esbuild-deno-loader";
+import * as esbuild from "npm:esbuild@0.24.2";
+import { denoPlugins } from "jsr:@luca/esbuild-deno-loader@0.11.1";
 
 export interface BundleOptions {
   entryPoint: string;


### PR DESCRIPTION
The issue was that `deno install --global --config=https://...` fails in Deno 2.x because Deno tries to resolve the URL as a local file path.

I fixed this by making the CLI self-contained. I updated `src/utils/bundler.ts` to use full specifiers for its dependencies (`esbuild` and `@luca/esbuild-deno-loader`), which eliminates the need for an import map or config file during installation.

I then updated the `README.md` to remove the problematic `--config` flag from the installation instructions.

All tests passed, and the fix was verified by simulating a global installation in the sandbox.

Fixes #19

---
*PR created automatically by Jules for task [11957429427934717187](https://jules.google.com/task/11957429427934717187) started by @Walkmana-25*