### PR TITLE
Add installation scripts for Deno and Sapphillon CLI

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,39 @@
+@echo off
+setlocal
+
+:: Check if Deno is installed
+where deno >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+    if exist "%USERPROFILE%\.deno\bin\deno.exe" (
+        echo Deno found in %USERPROFILE%\.deno\bin\deno.exe
+        set "PATH=%USERPROFILE%\.deno\bin;%PATH%"
+    ) else (
+        echo Deno not found. Installing Deno...
+        powershell -Command "irm https://deno.land/install.ps1 | iex"
+        set "PATH=%USERPROFILE%\.deno\bin;%PATH%"
+    )
+) else (
+    for /f "tokens=*" %%i in ('deno --version') do (
+        echo Deno is already installed: %%i
+        goto :deno_installed
+    )
+)
+
+:deno_installed
+:: Ensure Deno is in PATH for the rest of the script
+set "PATH=%USERPROFILE%\.deno\bin;%PATH%"
+
+echo Installing Sapphillon CLI...
+deno install --global -f -n sapphillon --allow-read --allow-write --allow-net --allow-run --allow-env main.ts
+
+echo Verifying installation...
+where sapphillon >nul 2>nul
+if %ERRORLEVEL% eq 0 (
+    echo Sapphillon CLI installed successfully!
+    sapphillon --version
+) else (
+    echo Error: Sapphillon CLI installation failed or not in PATH.
+    exit /b 1
+)
+
+endlocal

--- a/setup.bat
+++ b/setup.bat
@@ -9,6 +9,10 @@ if %ERRORLEVEL% neq 0 (
         set "PATH=%USERPROFILE%\.deno\bin;%PATH%"
     ) else (
         echo Deno not found. Installing Deno...
+        :: NOTE: This downloads and executes a remote PowerShell script. Review the
+        :: script at https://deno.land/install.ps1 before running, or install Deno
+        :: manually via a package manager (e.g. 'winget install DenoLand.Deno') if
+        :: you prefer not to pipe remote scripts directly to iex.
         powershell -Command "irm https://deno.land/install.ps1 | iex"
         set "PATH=%USERPROFILE%\.deno\bin;%PATH%"
     )
@@ -24,7 +28,7 @@ if %ERRORLEVEL% neq 0 (
 set "PATH=%USERPROFILE%\.deno\bin;%PATH%"
 
 echo Installing Sapphillon CLI...
-deno install --global -f -n sapphillon --allow-read --allow-write --allow-net --allow-run --allow-env main.ts
+deno install --global -f -n sapphillon --allow-read --allow-write --allow-net --allow-run --allow-env "%~dp0main.ts"
 
 echo Verifying installation...
 where sapphillon >nul 2>nul

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # Check if Deno is installed
 if ! command -v deno &> /dev/null; then
@@ -8,6 +8,10 @@ if ! command -v deno &> /dev/null; then
         export PATH="$HOME/.deno/bin:$PATH"
     else
         echo "Deno not found. Installing Deno..."
+        # NOTE: This downloads and executes a remote script. Review the script at
+        # https://deno.land/install.sh before running, or install Deno manually
+        # via a package manager (e.g. 'brew install deno' on macOS) if you prefer
+        # not to pipe remote scripts directly to sh.
         curl -fsSL https://deno.land/install.sh | sh
         export PATH="$HOME/.deno/bin:$PATH"
     fi
@@ -18,14 +22,22 @@ fi
 # Ensure Deno is in PATH for the rest of the script
 export PATH="$HOME/.deno/bin:$PATH"
 
+# Determine the directory of this script to build an absolute path to main.ts
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 echo "Installing Sapphillon CLI..."
-deno install --global -f -n sapphillon --allow-read --allow-write --allow-net --allow-run --allow-env main.ts
+deno install --global -f -n sapphillon --allow-read --allow-write --allow-net --allow-run --allow-env "$SCRIPT_DIR/main.ts"
 
 echo "Verifying installation..."
 if command -v sapphillon &> /dev/null; then
     echo "Sapphillon CLI installed successfully!"
     sapphillon --version
+    echo
+    echo "To use 'sapphillon' in new terminal sessions, ensure your PATH includes $HOME/.deno/bin."
+    echo "For example, add the following line to your shell profile (e.g. ~/.bashrc or ~/.zshrc):"
+    echo '    export PATH="$HOME/.deno/bin:$PATH"'
 else
     echo "Error: Sapphillon CLI installation failed or not in PATH."
+    echo "Please ensure that $HOME/.deno/bin is on your PATH and try running setup.sh again."
     exit 1
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# Check if Deno is installed
+if ! command -v deno &> /dev/null; then
+    if [ -f "$HOME/.deno/bin/deno" ]; then
+        echo "Deno found in $HOME/.deno/bin/deno"
+        export PATH="$HOME/.deno/bin:$PATH"
+    else
+        echo "Deno not found. Installing Deno..."
+        curl -fsSL https://deno.land/install.sh | sh
+        export PATH="$HOME/.deno/bin:$PATH"
+    fi
+else
+    echo "Deno is already installed: $(deno --version | head -n1)"
+fi
+
+# Ensure Deno is in PATH for the rest of the script
+export PATH="$HOME/.deno/bin:$PATH"
+
+echo "Installing Sapphillon CLI..."
+deno install --global -f -n sapphillon --allow-read --allow-write --allow-net --allow-run --allow-env main.ts
+
+echo "Verifying installation..."
+if command -v sapphillon &> /dev/null; then
+    echo "Sapphillon CLI installed successfully!"
+    sapphillon --version
+else
+    echo "Error: Sapphillon CLI installation failed or not in PATH."
+    exit 1
+fi


### PR DESCRIPTION
Added `setup.sh` (for Unix/Linux/macOS) and `setup.bat` (for Windows) to simplify the setup process for developers. Both scripts:
1. Check for Deno installation and install it if missing.
2. Temporarily update PATH to include Deno's bin directory.
3. Install the Sapphillon CLI globally using `deno install`.
4. Verify the installation by running `sapphillon --version`.

Fixes #21

---
*PR created automatically by Jules for task [15415879545030536929](https://jules.google.com/task/15415879545030536929) started by @Walkmana-25*